### PR TITLE
Add support for wpzoo/grunt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Thumbs.db
 
 # Node Modules
 node_modules
+grunt

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,72 +1,9 @@
-module.exports = function(grunt) {
-
-	grunt.initConfig({
-
-		sass: {
-			dist: {
-				options: {
-					sourcemap: 'none',
-					style: 'expanded'
-				},
-				files: {
-					'style.css': 'sass/style.scss'
-				}
-			}
-		},
-
-		fixindent: {
-			scripts: {
-				src: [
-					'style.css'
-				],
-				dest: 'style.css',
-				options: {
-					style: 'tab',
-					size: 1
-				}
-			}
-		},
-
-		cssmin: {
-			combine: {
-				files: {
-					'style.min.css': ['style.css']
-				}
-			}
-		},
-
-		uglify: {
-			my_target: {
-				files: {
-					'js/penguin.min.js': ['js/masonry-options.js', 'js/smooth-scroll.js', 'js/navigation.js', 'js/fluidvids.js', 'js/skip-link-focus-fix.js']
-				}
-			}
-		},
-
-		watch: {
-			options: {
-				livereload: true,
-			},
-			js: {
-				files: ['js/*.js'],
-				tasks: ['uglify'],
-			},
-			css: {
-				files: ['sass/**/*.scss'],
-				tasks: ['sass', 'fixindent', 'cssmin'],
-			},
+/* global require, process */
+module.exports = function( grunt ) {
+	// Load Grunt plugin configurations
+	require('load-grunt-config')(grunt, {
+		data: {
+			pkg: grunt.file.readJSON('package.json')
 		}
-
 	});
-
-grunt.loadNpmTasks('grunt-contrib-sass');
-grunt.loadNpmTasks('grunt-fixindent');
-grunt.loadNpmTasks('grunt-contrib-cssmin');
-grunt.loadNpmTasks('grunt-contrib-uglify');
-grunt.loadNpmTasks('grunt-contrib-watch');
-
-grunt.registerTask('default', ['watch']);
-grunt.registerTask('css', ['sass','fixindent','cssmin']);
-grunt.registerTask('js', ['uglify']);
-
 };

--- a/package.json
+++ b/package.json
@@ -1,25 +1,73 @@
 {
   "name": "penguin-gold",
-  "version": "1.0.0",
+  "capitalname": "PENGU!N Gold",
   "description": "WP Theme PENGU!N Gold",
-  "main": "Gruntfile.js",
-  "dependencies": {
-    "grunt": "^0.4.5"
+  "author": "Stefan Brechbühl",
+  "homepage": "https://wpzoo.ch/",
+  "version": "1.0.0",
+  "copyright": "2015",
+  "license": "GPL-2.0+",
+  "private": true,
+  "contributors": [
+    {
+      "name": "WPZOO",
+      "url": "wpzoo.ch"
+    },
+    {
+      "name": "Stefan Brechbühl",
+      "url": "pixelstrol.ch"
+    },
+    {
+      "name": "Ulrich Pogson",
+      "url": "ulrich.pogson.ch"
+    }
+  ],
+  "directories": {
+    "js": "./js",
+    "sass": "./sass",
+    "css": "",
+    "build": "./build"
   },
-  "devDependencies": {
-    "grunt-contrib-cssmin": "^0.10.0",
-    "grunt-contrib-sass": "^0.8.1",
-    "grunt-contrib-uglify": "^0.6.0",
-    "grunt-contrib-watch": "^0.6.1",
-    "grunt-fixindent": "^0.1.3"
+  "theme": {
+    "name": "PENGU!N Gold",
+    "uri": "http://wpzoo.ch/themes/penguin/",
+    "description": "PENGU!N is a clean and modern WordPress theme made by WPZOO. Besides the link color the used colors are monochromatic. The post thumbnail will be used as a big header image on single post pages as well as Pages. These theme characteristics make it possible to use PENGU!N for bloggin' as well as a magazin theme.",
+    "author": "WPZOO",
+    "authoruri": "http://wpzoo.ch",
+    "license": "GPL-2.0+",
+    "licenseuri": "http://www.gnu.org/licenses/gpl-2.0.html",
+    "textdomain": "penguin",
+    "domainpath": "/languages",
+    "tags": "black, blue, gray, white, light, one-column, two-columns, right-sidebar, left-sidebar, responsive-layout, accessibility-ready, custom-menu, featured-image-header,featured-images, post-formats, sticky-post, threaded-comments, translation-ready"
+  },
+  "bugs": {
+    "url": "https://github.com/WPZOO/penguin-gold/issues",
+    "email": "support@wpzoo.ch"
+  },
+  "pot": {
+    "reportmsgidbugsto": "WPZOO Translations <translations@wpzoo.ch>",
+    "lasttranslator": "WPZOO Translations <translations@wpzoo.ch>",
+    "languageteam": "WPZOO Translations <translations@wpzoo.ch>",
+    "type": "wp-theme"
   },
   "repository": {
     "type": "git",
-    "url": "https://pixelstrolch@github.com/WPZOO/penguin-gold"
+    "url": "https://github.com/WPZOO/penguin-gold.git"
   },
-  "author": "Stefan Brechbühl",
-  "license": "GPL",
-  "bugs": {
-    "url": "https://github.com/WPZOO/penguin-gold/issues"
+  "devDependencies": {
+    "grunt": "*",
+    "load-grunt-config": "*",
+    "grunt-checktextdomain": "*",
+    "grunt-contrib-imagemin": "*",
+    "grunt-contrib-sass": "*",
+    "grunt-wp-css": "*",
+    "grunt-cssjanus": "*",
+    "grunt-contrib-cssmin": "*",
+    "grunt-contrib-uglify": "*",
+    "grunt-contrib-watch": "*",
+    "grunt-wp-i18n": "*",
+    "grunt-newer": "*",
+    "grunt-potomo": "*",
+    "grunt-exec": "*"
   }
 }


### PR DESCRIPTION
I have created a repo with all of our grunt tasks: https://github.com/wpzoo/grunt

All of the variables are defined in the package.json

I would like to make a few changes for the future
- Create a CSS folder for all of the css
- Load a separate CSS for the RTL styles instead of loading an extra stylesheet to overwrite the styles.
- I don't think we should merge all of the js into one file but have single minified files